### PR TITLE
Fix docstrings indented with spaces when using tabs

### DIFF
--- a/src/black/__init__.py
+++ b/src/black/__init__.py
@@ -2116,7 +2116,9 @@ class LineGenerator(Visitor[Line]):
             tail_len = -3
             indent_style = " " * 4 if not self.use_tabs else "\t"
             indent = indent_style * self.current_line.depth
-            docstring = fix_docstring(leaf.value[lead_len:tail_len], indent)
+            docstring = fix_docstring(
+                leaf.value[lead_len:tail_len], indent, not self.use_tabs
+            )
             if docstring:
                 if leaf.value[lead_len - 1] == docstring[0]:
                     docstring = " " + docstring
@@ -6854,11 +6856,14 @@ def lines_with_leading_tabs_expanded(s: str) -> List[str]:
     return lines
 
 
-def fix_docstring(docstring: str, prefix: str) -> str:
+def fix_docstring(docstring: str, prefix: str, expand_leading_tabs: bool) -> str:
     # https://www.python.org/dev/peps/pep-0257/#handling-docstring-indentation
     if not docstring:
         return ""
-    lines = lines_with_leading_tabs_expanded(docstring)
+    if expand_leading_tabs:
+        lines = lines_with_leading_tabs_expanded(docstring)
+    else:
+        lines = docstring.splitlines()
     # Determine minimum indentation (first line doesn't count):
     indent = sys.maxsize
     for line in lines[1:]:

--- a/src/black/__init__.py
+++ b/src/black/__init__.py
@@ -2114,7 +2114,8 @@ class LineGenerator(Visitor[Line]):
             prefix = get_string_prefix(leaf.value)
             lead_len = len(prefix) + 3
             tail_len = -3
-            indent = " " * 4 * self.current_line.depth
+            indent_style = " " * 4 if not self.use_tabs else "\t"
+            indent = indent_style * self.current_line.depth
             docstring = fix_docstring(leaf.value[lead_len:tail_len], indent)
             if docstring:
                 if leaf.value[lead_len - 1] == docstring[0]:

--- a/tests/data/docstring_tabs.py
+++ b/tests/data/docstring_tabs.py
@@ -1,0 +1,276 @@
+class MyClass:
+  """ Multiline
+  class docstring
+  """
+
+  def method(self):
+    """Multiline
+    method docstring
+    """
+    pass
+
+
+def foo():
+  """This is a docstring with             
+  some lines of text here
+  """
+  return
+
+
+def bar():
+  '''This is another docstring
+  with more lines of text
+  '''
+  return
+
+
+def baz():
+  '''"This" is a string with some
+  embedded "quotes"'''
+  return
+
+
+def troz():
+	'''Indentation with tabs
+	is just as OK
+	'''
+	return
+
+
+def zort():
+        """Another
+        multiline
+        docstring
+        """
+        pass
+
+def poit():
+  """
+  Lorem ipsum dolor sit amet.       
+
+  Consectetur adipiscing elit:
+   - sed do eiusmod tempor incididunt ut labore
+   - dolore magna aliqua
+     - enim ad minim veniam
+     - quis nostrud exercitation ullamco laboris nisi
+   - aliquip ex ea commodo consequat
+  """
+  pass
+
+
+def under_indent():
+  """
+  These lines are indented in a way that does not
+make sense.
+  """
+  pass
+
+
+def over_indent():
+  """
+  This has a shallow indent
+    - But some lines are deeper
+    - And the closing quote is too deep
+    """
+  pass
+
+
+def single_line():
+    """But with a newline after it!
+
+    """
+    pass
+
+
+def this():
+    r"""
+    'hey ho'
+    """
+
+
+def that():
+  """ "hey yah" """
+
+
+def and_that():
+  """
+  "hey yah" """
+
+
+def and_this():
+  ''' 
+  "hey yah"'''
+
+
+def believe_it_or_not_this_is_in_the_py_stdlib(): ''' 
+"hey yah"'''
+
+
+def ignored_docstring():
+    """a => \
+b"""  
+
+
+def docstring_with_inline_tabs_and_space_indentation():
+    """hey
+
+    tab	separated	value
+    	tab at start of line and then a tab	separated	value
+    				multiple tabs at the beginning	and	inline
+    	 	  	mixed tabs and spaces at beginning. next line has mixed tabs and spaces only.
+    			 	  		
+    line ends with some tabs		
+    """
+
+
+def docstring_with_inline_tabs_and_tab_indentation():
+	"""hey
+
+	tab	separated	value
+		tab at start of line and then a tab	separated	value
+					multiple tabs at the beginning	and	inline
+		 	  	mixed tabs and spaces at beginning. next line has mixed tabs and spaces only.
+				 	  		
+	line ends with some tabs		
+	"""
+	pass
+        
+
+# output
+
+class MyClass:
+	"""Multiline
+	class docstring
+	"""
+
+	def method(self):
+		"""Multiline
+		method docstring
+		"""
+		pass
+
+
+def foo():
+	"""This is a docstring with
+	some lines of text here
+	"""
+	return
+
+
+def bar():
+	"""This is another docstring
+	with more lines of text
+	"""
+	return
+
+
+def baz():
+	'''"This" is a string with some
+	embedded "quotes"'''
+	return
+
+
+def troz():
+	"""Indentation with tabs
+	is just as OK
+	"""
+	return
+
+
+def zort():
+	"""Another
+	multiline
+	docstring
+	"""
+	pass
+
+
+def poit():
+	"""
+	Lorem ipsum dolor sit amet.
+
+	Consectetur adipiscing elit:
+	 - sed do eiusmod tempor incididunt ut labore
+	 - dolore magna aliqua
+	   - enim ad minim veniam
+	   - quis nostrud exercitation ullamco laboris nisi
+	 - aliquip ex ea commodo consequat
+	"""
+	pass
+
+
+def under_indent():
+	"""
+	  These lines are indented in a way that does not
+	make sense.
+	"""
+	pass
+
+
+def over_indent():
+	"""
+	This has a shallow indent
+	  - But some lines are deeper
+	  - And the closing quote is too deep
+	"""
+	pass
+
+
+def single_line():
+	"""But with a newline after it!"""
+	pass
+
+
+def this():
+	r"""
+	'hey ho'
+	"""
+
+
+def that():
+	""" "hey yah" """
+
+
+def and_that():
+	"""
+	"hey yah" """
+
+
+def and_this():
+	'''
+	"hey yah"'''
+
+
+def believe_it_or_not_this_is_in_the_py_stdlib():
+	'''
+	"hey yah"'''
+
+
+def ignored_docstring():
+	"""a => \
+b"""
+
+
+def docstring_with_inline_tabs_and_space_indentation():
+	"""hey
+
+	tab	separated	value
+	    tab at start of line and then a tab	separated	value
+	                            multiple tabs at the beginning	and	inline
+	                    mixed tabs and spaces at beginning. next line has mixed tabs and spaces only.
+
+	line ends with some tabs
+	"""
+
+
+def docstring_with_inline_tabs_and_tab_indentation():
+	"""hey
+
+	tab	separated	value
+	        tab at start of line and then a tab	separated	value
+	                                multiple tabs at the beginning	and	inline
+	                        mixed tabs and spaces at beginning. next line has mixed tabs and spaces only.
+
+	line ends with some tabs
+	"""
+	pass

--- a/tests/data/docstring_tabs.py
+++ b/tests/data/docstring_tabs.py
@@ -255,9 +255,9 @@ def docstring_with_inline_tabs_and_space_indentation():
 	"""hey
 
 	tab	separated	value
-	    tab at start of line and then a tab	separated	value
-	                            multiple tabs at the beginning	and	inline
-	                    mixed tabs and spaces at beginning. next line has mixed tabs and spaces only.
+		tab at start of line and then a tab	separated	value
+					multiple tabs at the beginning	and	inline
+		 	  	mixed tabs and spaces at beginning. next line has mixed tabs and spaces only.
 
 	line ends with some tabs
 	"""
@@ -267,9 +267,9 @@ def docstring_with_inline_tabs_and_tab_indentation():
 	"""hey
 
 	tab	separated	value
-	        tab at start of line and then a tab	separated	value
-	                                multiple tabs at the beginning	and	inline
-	                        mixed tabs and spaces at beginning. next line has mixed tabs and spaces only.
+		tab at start of line and then a tab	separated	value
+					multiple tabs at the beginning	and	inline
+		 	  	mixed tabs and spaces at beginning. next line has mixed tabs and spaces only.
 
 	line ends with some tabs
 	"""

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -104,3 +104,11 @@ class TestSimpleFormat(BlackBaseTestCase):
         self.assertFormatEqual(expected, actual)
         black.assert_equivalent(source, actual)
         black.assert_stable(source, actual, black.FileMode(use_tabs=True))
+
+    @patch("black.dump_to_file", dump_to_stderr)
+    def test_docstring_tabs(self) -> None:
+        source, expected = read_data("docstring_tabs")
+        actual = fs(source, mode=black.FileMode(use_tabs=True))
+        self.assertFormatEqual(expected, actual)
+        black.assert_equivalent(source, actual)
+        black.assert_stable(source, actual, black.FileMode(use_tabs=True))


### PR DESCRIPTION
* Multiline docstrings were always being indented with spaces. They are now indented with tabs when `--use-tabs` is enabled.

* Leading tabs inside multiline docstrings are no longer expanded to spaces when `--use-tabs` is enabled. I figure if you're using tab indentation, you'd probably want tabs maintained inside docstrings rather than a mix of tabs and spaces.

* Added a test for this based on the existing docstring test data.