### PR TITLE
Fix case where tabs can exceed line length

### DIFF
--- a/src/black/__init__.py
+++ b/src/black/__init__.py
@@ -6501,6 +6501,8 @@ def is_line_short_enough(line: Line, *, line_length: int, line_str: str = "") ->
     if not line_str:
         # Force spaces to ensure len(line) is correct
         line_str = line.render(force_spaces=True).strip("\n")
+    else:
+        line_str = line_str.expandtabs(tabsize=4)
     return (
         len(line_str) <= line_length
         and "\n" not in line_str  # multiline strings

--- a/tests/data/line_length_tabs.py
+++ b/tests/data/line_length_tabs.py
@@ -1,0 +1,21 @@
+print("xxxxxxxxxxx")
+print("xxxxxxxxxxxx")
+
+
+def f():
+    print("xxxxxxx")
+    print("xxxxxxxx")
+
+# output
+
+print("xxxxxxxxxxx")
+print(
+	"xxxxxxxxxxxx"
+)
+
+
+def f():
+	print("xxxxxxx")
+	print(
+		"xxxxxxxx"
+	)

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -104,3 +104,13 @@ class TestSimpleFormat(BlackBaseTestCase):
         self.assertFormatEqual(expected, actual)
         black.assert_equivalent(source, actual)
         black.assert_stable(source, actual, black.FileMode(use_tabs=True))
+
+    @patch("black.dump_to_file", dump_to_stderr)
+    def test_line_length_tabs(self) -> None:
+        source, expected = read_data("line_length_tabs")
+        actual = fs(source, mode=black.FileMode(line_length=20, use_tabs=True))
+        self.assertFormatEqual(expected, actual)
+        black.assert_equivalent(source, actual)
+        black.assert_stable(
+            source, actual, black.FileMode(line_length=20, use_tabs=True)
+        )


### PR DESCRIPTION
* In `is_line_sort_enough`, spaces are forced when `line_str` is not given. If `line_str` is given, then they are not forced which results in tabs being counted as 1 character instead of 4. Tabs are now expanded to 4 characters in this case.

* Added a test for this. (Note: there will probably be a merge conflict with #8 also modifying `test_format.py`.)